### PR TITLE
Revert "Implemented front-end emoji reaction feature for chat messages, inclu…"

### DIFF
--- a/src/views/partials/chats/message.tpl
+++ b/src/views/partials/chats/message.tpl
@@ -77,7 +77,7 @@
                             <a href="#" class="dropdown-item rounded-1" data-action="restore" role="menuitem"><span class="d-inline-flex align-items-center gap-2"><i class="fa fa-fw fa-repeat text-muted"></i> [[topic:restore]]</span></a>
                         </li>
                         {{{ end }}}
-						#
+
                         {{{ if (isAdminOrGlobalMod || isOwner )}}}
                         <li>
                             <a href="#" class="dropdown-item rounded-1" data-action="pin" role="menuitem"><span class="d-inline-flex align-items-center gap-2"><i class="fa fa-fw fa-thumbtack text-muted"></i> [[modules:chat.pin-message]]</span></a>


### PR DESCRIPTION
Reverts CMU-17313Q/nodebb-f24-swifties#43, since the reviewers did not approve yet.

We recently encountered an issue where multiple pull requests were merged without adhering to the required guidelines. Mainly, we merged without the reviewers confirming first on GitHub. We did this because when we added the reviewers, the merge button was still clickable, so we thought in this assignment it was okay to merge as long as reviewers just took a look and were okay with it, having worked right next to each other, without clicking the button on git. To resolve this, and create pull requests with proper reviewer GitHub acceptance, we had to revert each of the pull requests individually, rolling the codebase back to the starting point before these changes were introduced. This process was necessary to ensure stability and compliance with the project’s guidelines, and we are now taking corrective steps to follow proper procedures going forward to avoid similar setbacks. As a next step, we will revert the reverts from the newest one to the oldest one with the reviewers assigned and confirmed, so that we are essentially doing everything correctly as if from the beginning code.