### PR TITLE
Revert "modified lint errors with comments out and added the last code to make the code full"

### DIFF
--- a/node_modules_real/composer.js
+++ b/node_modules_real/composer.js
@@ -198,24 +198,6 @@
 //      formatting.addButton(iconClass, onClick, title);
 //  };
 
-// Adding event listener for MP3 upload button
-// composer.addButton('fa-file-audio-o', function () {
-//     document.getElementById('mp3-files').click();  // Trigger the hidden MP3 file input
-// }, 'Upload MP3');
-
-// // Handle MP3 file selection and trigger the upload process
-// document.getElementById('mp3-files').addEventListener('change', function (e) {
-//     const files = e.target.files;
-//     if (files && files.length) {
-//         // Call the general file upload function from the uploads module
-//         uploads.uploadContentFiles({
-//             files: files,                 // The selected MP3 files
-//             post_uuid: composer.active,    // The active post (to track the composer instance)
-//             route: '/api/post/upload'      // The route for file upload
-//         });
-//     }
-// });
-
 //  composer.newTopic = async (data) => {
 //      let pushData = {
 //      save_id: data.save_id,


### PR DESCRIPTION
Reverts CMU-17313Q/nodebb-f24-swifties#42

We recently encountered an issue where multiple pull requests were merged without adhering to the required guidelines. Mainly, we merged without the reviewers confirming first on GitHub. We did this because when we added the reviewers, the merge button was still clickable, so we thought in this assignment it was okay to merge as long as reviewers just took a look and were okay with it, having worked right next to each other, without clicking the button on git. To resolve this, and create pull requests with proper reviewer GitHub acceptance, we had to revert each of the pull requests individually, rolling the codebase back to the starting point before these changes were introduced. This process was necessary to ensure stability and compliance with the project’s guidelines, and we are now taking corrective steps to follow proper procedures going forward to avoid similar setbacks. As a next step, we will revert the reverts from the newest one to the oldest one with the reviewers assigned and confirmed, so that we are essentially doing everything correctly as if from the beginning code.