### PR TITLE
Revert "Added Front-End Emoji Reaction UI for Chat Messages"

### DIFF
--- a/src/views/partials/chats/message.tpl
+++ b/src/views/partials/chats/message.tpl
@@ -1,113 +1,76 @@
-<!-- Check if the message is a reaction message -->
-{{{ if messages.reactionTo }}}
-<li component="chat/message" class="chat-message reaction-message mx-2 pe-2" data-mid="{messages.messageId}">
-  <div class="message-body-wrapper">
-    <div class="message-body ps-0 py-0 overflow-auto text-break">
-      <!-- Display the reacting user's avatar and name -->
-      <a href="{config.relative_path}/user/{messages.reactionFromUser.userslug}" class="text-decoration-none">
-        {buildAvatar(messages.reactionFromUser, "18px", true, "not-responsive")}
-      </a>
-      <span class="chat-user fw-semibold">
-        <a href="{config.relative_path}/user/{messages.reactionFromUser.userslug}">{messages.reactionFromUser.displayname}</a>
-      </span>
-      <!-- Display the reaction message content -->
-      <span>reacted {messages.reactionEmoji} to <a href="{config.relative_path}/message/{messages.reactionTo}">message {messages.reactionTo}</a></span>
-    </div>
-  </div>
+<li component="chat/message" class="chat-message mx-2 pe-2 {{{ if messages.deleted }}} deleted{{{ end }}} {{{ if messages.pinned}}} pinned{{{ end }}} {{{ if messages.newSet }}}border-top pt-3{{{ end }}}" data-mid="{messages.messageId}" data-uid="{messages.fromuid}" data-index="{messages.index}" data-self="{messages.self}" data-break="{messages.newSet}" data-timestamp="{messages.timestamp}" data-username="{messages.fromUser.username}">
+
+	{{{ if messages.parent }}}
+	<!-- IMPORT partials/chats/parent.tpl -->
+	{{{ end }}}
+
+	<div class="message-header lh-1 d-flex align-items-center gap-2 text-sm {{{ if !messages.newSet }}}hidden{{{ end }}} pb-2">
+		<a href="{config.relative_path}/user/{messages.fromUser.userslug}" class="text-decoration-none">{buildAvatar(messages.fromUser, "18px", true, "not-responsive")}</a>
+		<span class="chat-user fw-semibold"><a href="{config.relative_path}/user/{messages.fromUser.userslug}">{messages.fromUser.displayname}</a></span>
+		{{{ if messages.fromUser.banned }}}
+		<span class="badge bg-danger">[[user:banned]]</span>
+		{{{ end }}}
+		{{{ if messages.fromUser.deleted }}}
+		<span class="badge bg-danger">[[user:deleted]]</span>
+		{{{ end }}}
+		<span class="chat-timestamp text-muted timeago" title="{messages.timestampISO}"></span>
+
+		<div component="chat/message/edited" class="text-muted ms-auto {{{ if !messages.edited }}}hidden{{{ end }}}" title="[[global:edited-timestamp, {isoTimeToLocaleString(messages.editedISO, config.userLang)}]]"><i class="fa fa-edit"></i></span></div>
+	</div>
+	<div class="message-body-wrapper">
+		<div component="chat/message/body" class="message-body ps-0 py-0 overflow-auto text-break">
+			{messages.content}
+		</div>
+		<!-- IMPORT partials/chats/reactions.tpl -->
+		<div component="chat/message/controls" class="position-relative">
+			<div class="btn-group border shadow-sm controls position-absolute bg-body end-0" style="bottom:1rem;">
+				<!-- IMPORT partials/chats/add-reaction.tpl -->
+				<button class="btn btn-sm btn-link" data-action="reply" title="[[topic:reply]]"><i class="fa fa-reply"></i></button>
+
+				<div class="btn-group d-inline-block">
+					<button class="btn btn-sm btn-link dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-ellipsis" type="button"></i></button>
+					<ul class="dropdown-menu dropdown-menu-end p-1 text-sm list-unstyled" role="menu">
+						{{{ if (isAdminOrGlobalMod || (!config.disableChatMessageEditing && messages.self)) }}}
+						<li>
+							<a href="#" class="dropdown-item rounded-1" data-action="edit" role="menuitem"><span class="d-inline-flex align-items-center gap-2"><i class="fa fa-fw fa-pencil text-muted"></i> [[topic:edit]]</span></a>
+						</li>
+						<li>
+							<a href="#" class="dropdown-item rounded-1" data-action="delete" role="menuitem"><span class="d-inline-flex align-items-center gap-2"><i class="fa fa-fw fa-trash text-muted"></i> [[topic:delete]]</span></a>
+						</li>
+						<li>
+							<a href="#" class="dropdown-item rounded-1" data-action="restore" role="menuitem"><span class="d-inline-flex align-items-center gap-2"><i class="fa fa-fw fa-repeat text-muted"></i> [[topic:restore]]</span></a>
+						</li>
+						{{{ end }}}
+
+						{{{ if (isAdminOrGlobalMod || isOwner )}}}
+						<li>
+							<a href="#" class="dropdown-item rounded-1" data-action="pin" role="menuitem"><span class="d-inline-flex align-items-center gap-2"><i class="fa fa-fw fa-thumbtack text-muted"></i> [[modules:chat.pin-message]]</span></a>
+						</li>
+						<li>
+							<a href="#" class="dropdown-item rounded-1" data-action="unpin" role="menuitem"><span class="d-inline-flex align-items-center gap-2"><i class="fa fa-fw fa-thumbtack fa-rotate-90 text-muted"></i> [[modules:chat.unpin-message]]</span></a>
+						</li>
+						<li class="dropdown-divider"></li>
+						{{{ end }}}
+
+						{{{ if isAdminOrGlobalMod }}}
+						<li>
+							<a href="#" class="dropdown-item rounded-1 chat-ip-button" role="menuitem">
+								<span class="d-inline-flex align-items-center gap-2 show"><i class="fa fa-fw fa-info-circle text-muted"></i> [[modules:chat.show-ip]]</span>
+								<span class="d-inline-flex align-items-center gap-2 copy hidden"><i class="fa fa-fw fa-copy text-muted"></i> <span class="copy-ip-text"></span></span>
+							</a>
+						</li>
+						{{{ end }}}
+
+						<li>
+							<a href="#" class="dropdown-item rounded-1" data-action="copy-text" data-mid="{messages.mid}" role="menuitem"><span class="d-inline-flex align-items-center gap-2"><i class="fa fa-fw fa-copy text-muted"></i> [[modules:chat.copy-text]]</span></a>
+						</li>
+
+						<li>
+							<a href="#" class="dropdown-item rounded-1" data-action="copy-link" data-mid="{messages.mid}" role="menuitem"><span class="d-inline-flex align-items-center gap-2"><i class="fa fa-fw fa-link text-muted"></i> [[modules:chat.copy-link]]</span></a>
+						</li>
+					</ul>
+				</div>
+			</div>
+		</div>
+	</div>
 </li>
-{{{ else }}}
-<!-- Regular message template for normal chat messages -->
-<li component="chat/message" class="chat-message mx-2 pe-2 {{{ if messages.deleted }}} deleted{{{ end }}} {{{ if messages.pinned }}} pinned{{{ end }}} {{{ if messages.newSet }}} border-top pt-3{{{ end }}}" data-mid="{messages.messageId}" data-uid="{messages.fromuid}" data-index="{messages.index}" data-self="{messages.self}" data-break="{messages.newSet}" data-timestamp="{messages.timestamp}" data-username="{messages.fromUser.username}">
-
-    {{{ if messages.parent }}}
-    <!-- IMPORT partials/chats/parent.tpl -->
-    {{{ end }}}
-
-    <div class="message-header lh-1 d-flex align-items-center gap-2 text-sm {{{ if !messages.newSet }}} hidden{{{ end }}} pb-2">
-        <a href="{config.relative_path}/user/{messages.fromUser.userslug}" class="text-decoration-none">{buildAvatar(messages.fromUser, "18px", true, "not-responsive")}</a>
-        <span class="chat-user fw-semibold"><a href="{config.relative_path}/user/{messages.fromUser.userslug}">{messages.fromUser.displayname}</a></span>
-        {{{ if messages.fromUser.banned }}}
-        <span class="badge bg-danger">[[user:banned]]</span>
-        {{{ end }}}
-        {{{ if messages.fromUser.deleted }}}
-        <span class="badge bg-danger">[[user:deleted]]</span>
-        {{{ end }}}
-        <span class="chat-timestamp text-muted timeago" title="{messages.timestampISO}"></span>
-
-        <div component="chat/message/edited" class="text-muted ms-auto {{{ if !messages.edited }}} hidden{{{ end }}}" title="[[global:edited-timestamp, {isoTimeToLocaleString(messages.editedISO, config.userLang)}]]"><i class="fa fa-edit"></i></div>
-    </div>
-    <div class="message-body-wrapper position-relative">
-        <div component="chat/message/body" class="message-body ps-0 py-0 overflow-auto text-break">
-            {messages.content}
-        </div>
-
-        <!-- Emoji Reaction UI -->
-        <div component="chat/message/controls" class="position-relative">
-            <div class="btn-group border shadow-sm controls position-absolute bg-body end-0" style="bottom:1rem;">
-                <!-- React Button -->
-                <div class="react-wrapper position-relative d-inline-block">
-                    <button class="btn btn-sm btn-link" data-action="react" title="React">
-                        <i class="fa fa-smile"></i>
-                    </button>
-
-                    <!-- Emoji Menu -->
-                    <div class="emoji-menu position-absolute bg-light border rounded shadow-sm p-2" style="display: none;">
-                        <span class="emoji-option" data-emoji="👍">👍</span>
-                        <span class="emoji-option" data-emoji="❤️">❤️</span>
-                        <span class="emoji-option" data-emoji="😂">😂</span>
-                        <span class="emoji-option" data-emoji="😮">😮</span>
-                        <span class="emoji-option" data-emoji="😢">😢</span>
-                        <span class="emoji-option" data-emoji="😡">😡</span>
-                    </div>
-                </div>
-
-                <button class="btn btn-sm btn-link" data-action="reply" title="[[topic:reply]]"><i class="fa fa-reply"></i></button>
-
-                <div class="btn-group d-inline-block">
-                    <button class="btn btn-sm btn-link dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-ellipsis" type="button"></i></button>
-                    <ul class="dropdown-menu dropdown-menu-end p-1 text-sm list-unstyled" role="menu">
-                        {{{ if (isAdminOrGlobalMod || (!config.disableChatMessageEditing && messages.self)) }}}
-                        <li>
-                            <a href="#" class="dropdown-item rounded-1" data-action="edit" role="menuitem"><span class="d-inline-flex align-items-center gap-2"><i class="fa fa-fw fa-pencil text-muted"></i> [[topic:edit]]</span></a>
-                        </li>
-                        <li>
-                            <a href="#" class="dropdown-item rounded-1" data-action="delete" role="menuitem"><span class="d-inline-flex align-items-center gap-2"><i class="fa fa-fw fa-trash text-muted"></i> [[topic:delete]]</span></a>
-                        </li>
-                        <li>
-                            <a href="#" class="dropdown-item rounded-1" data-action="restore" role="menuitem"><span class="d-inline-flex align-items-center gap-2"><i class="fa fa-fw fa-repeat text-muted"></i> [[topic:restore]]</span></a>
-                        </li>
-                        {{{ end }}}
-
-                        {{{ if (isAdminOrGlobalMod || isOwner )}}}
-                        <li>
-                            <a href="#" class="dropdown-item rounded-1" data-action="pin" role="menuitem"><span class="d-inline-flex align-items-center gap-2"><i class="fa fa-fw fa-thumbtack text-muted"></i> [[modules:chat.pin-message]]</span></a>
-                        </li>
-                        <li>
-                            <a href="#" class="dropdown-item rounded-1" data-action="unpin" role="menuitem"><span class="d-inline-flex align-items-center gap-2"><i class="fa fa-fw fa-thumbtack fa-rotate-90 text-muted"></i> [[modules:chat.unpin-message]]</span></a>
-                        </li>
-                        <li class="dropdown-divider"></li>
-                        {{{ end }}}
-
-                        {{{ if isAdminOrGlobalMod }}}
-                        <li>
-                            <a href="#" class="dropdown-item rounded-1 chat-ip-button" role="menuitem">
-                                <span class="d-inline-flex align-items-center gap-2 show"><i class="fa fa-fw fa-info-circle text-muted"></i> [[modules:chat.show-ip]]</span>
-                                <span class="d-inline-flex align-items-center gap-2 copy hidden"><i class="fa fa-fw fa-copy text-muted"></i> <span class="copy-ip-text"></span></span>
-                            </a>
-                        </li>
-                        {{{ end }}}
-
-                        <li>
-                            <a href="#" class="dropdown-item rounded-1" data-action="copy-text" data-mid="{messages.mid}" role="menuitem"><span class="d-inline-flex align-items-center gap-2"><i class="fa fa-fw fa-copy text-muted"></i> [[modules:chat.copy-text]]</span></a>
-                        </li>
-
-                        <li>
-                            <a href="#" class="dropdown-item rounded-1" data-action="copy-link" data-mid="{messages.mid}" role="menuitem"><span class="d-inline-flex align-items-center gap-2"><i class="fa fa-fw fa-link text-muted"></i> [[modules:chat.copy-link]]</span></a>
-                        </li>
-                    </ul>
-                </div>
-            </div>
-        </div>
-    </div>
-</li>
-{{{ end }}}


### PR DESCRIPTION
Reverts CMU-17313Q/nodebb-f24-swifties#38

We recently encountered an issue where multiple pull requests were merged without adhering to the required guidelines. Mainly, we merged without the reviewers confirming first on GitHub. We did this because when we added the reviewers, the merge button was still clickable, so we thought in this assignment it was okay to merge as long as reviewers just took a look and were okay with it, having worked right next to each other, without clicking the button on git. To resolve this, and create pull requests with proper reviewer GitHub acceptance, we had to revert each of the pull requests individually, rolling the codebase back to the starting point before these changes were introduced. This process was necessary to ensure stability and compliance with the project’s guidelines, and we are now taking corrective steps to follow proper procedures going forward to avoid similar setbacks. As a next step, we will revert the reverts from the newest one to the oldest one with the reviewers assigned and confirmed, so that we are essentially doing everything correctly as if from the beginning code.