### PR TITLE
Revert "replicated project1 changes here too"

### DIFF
--- a/src/upgrades/1.1.1/upload_privileges.js
+++ b/src/upgrades/1.1.1/upload_privileges.js
@@ -1,77 +1,38 @@
 'use strict';
 
+const async = require('async');
 const db = require('../../database');
+
 
 module.exports = {
 	name: 'Giving upload privileges',
 	timestamp: Date.UTC(2016, 6, 12),
-	method: async function () {
-		console.log('graissov: Executing method function');
+	method: function (callback) {
 		const privilegesAPI = require('../../privileges');
 		const meta = require('../../meta');
 
-		const cids = await getCategoryIds();
-		await processCategories(cids, privilegesAPI, meta);
-	},
-};
-
-// Helper function to get category IDs
-function getCategoryIds() {
-	console.log('graissov: Executing getCategoryIds function');
-	return new Promise((resolve, reject) => {
 		db.getSortedSetRange('categories:cid', 0, -1, (err, cids) => {
 			if (err) {
-				return reject(err);
+				return callback(err);
 			}
-			resolve(cids);
+
+			async.eachSeries(cids, (cid, next) => {
+				privilegesAPI.categories.list(cid, (err, data) => {
+					if (err) {
+						return next(err);
+					}
+					async.eachSeries(data.groups, (group, next) => {
+						if (group.name === 'guests' && parseInt(meta.config.allowGuestUploads, 10) !== 1) {
+							return next();
+						}
+						if (group.privileges['groups:read']) {
+							privilegesAPI.categories.give(['upload:post:image'], cid, group.name, next);
+						} else {
+							next();
+						}
+					}, next);
+				});
+			}, callback);
 		});
-	});
-}
-
-// Helper function to process each category
-async function processCategories(cids, privilegesAPI, meta) {
-	console.log('graissov: Executing processCategories function');
-	await Promise.all(cids.map(async (cid) => {
-		const data = await getCategoryData(cid, privilegesAPI);
-		await processGroups(data.groups, cid, privilegesAPI, meta);
-	}));
-}
-
-// Helper function to get category data
-function getCategoryData(cid, privilegesAPI) {
-	console.log('graissov: Executing getCategoryData function');
-	return new Promise((resolve, reject) => {
-		privilegesAPI.categories.list(cid, (err, data) => {
-			if (err) {
-				return reject(err);
-			}
-			resolve(data);
-		});
-	});
-}
-
-// Helper function to process groups within a category
-async function processGroups(groups, cid, privilegesAPI, meta) {
-	console.log('graissov: Executing processGroups function');
-	await Promise.all(groups.map(async (group) => {
-		if (group.name === 'guests' && parseInt(meta.config.allowGuestUploads, 10) !== 1) {
-			return; // Skip guests if uploads are not allowed
-		}
-		if (group.privileges['groups:read']) {
-			await giveUploadPrivilege(cid, group.name, privilegesAPI);
-		}
-	}));
-}
-
-// Helper function to give upload privileges
-function giveUploadPrivilege(cid, groupName, privilegesAPI) {
-	console.log('graissov: Executing giveUploadPrivilege function');
-	return new Promise((resolve, reject) => {
-		privilegesAPI.categories.give(['upload:post:image'], cid, groupName, (err) => {
-			if (err) {
-				return reject(err);
-			}
-			resolve();
-		});
-	});
-}
+	},
+};


### PR DESCRIPTION
Reverts CMU-17313Q/nodebb-f24-swifties#31

We recently encountered an issue where multiple pull requests were merged without adhering to the required guidelines. Mainly, we merged without the reviewers confirming first on GitHub. We did this because when we added the reviewers, the merge button was still clickable, so we thought in this assignment it was okay to merge as long as reviewers just took a look and were okay with it, having worked right next to each other, without clicking the button on git. To resolve this, and create pull requests with proper reviewer GitHub acceptance, we had to revert each of the pull requests individually, rolling the codebase back to the starting point before these changes were introduced. This process was necessary to ensure stability and compliance with the project’s guidelines, and we are now taking corrective steps to follow proper procedures going forward to avoid similar setbacks. As a next step, we will revert the reverts from the newest one to the oldest one with the reviewers assigned and confirmed, so that we are essentially doing everything correctly as if from the beginning code.