### PR TITLE
Revert "Matched sound_settings.js to match project one's file "

### DIFF
--- a/src/upgrades/1.4.4/sound_settings.js
+++ b/src/upgrades/1.4.4/sound_settings.js
@@ -2,76 +2,64 @@
 
 const async = require('async');
 const db = require('../../database');
-const meta = require('../../meta');
-const batch = require('../../batch');
 
-const soundMap = {
-	'notification.mp3': 'Default | Deedle-dum',
-	'waterdrop-high.mp3': 'Default | Water drop (high)',
-	'waterdrop-low.mp3': 'Default | Water drop (low)',
-};
-
-function updateGlobalSoundSettings(callback) {
-	console.log('Seckhen Ariel Andrade Cuellar');
-	const keys = ['chat-incoming', 'chat-outgoing', 'notification'];
-	db.getObject('settings:sounds', (err, settings) => {
-		if (err || !settings) {
-			return callback(err);
-		}
-
-		const updatedSettings = keys.reduce((acc, key) => {
-			if (settings[key] && !settings[key].includes(' | ')) {
-				acc[key] = soundMap[settings[key]] || '';
-			}
-			return acc;
-		}, {});
-
-		meta.configs.setMultiple(updatedSettings, callback);
-	});
-}
-
-function updateUserSoundSettings(callback) {
-	console.log('Seckhen Ariel Andrade Cuellar');
-
-	const keys = ['notificationSound', 'incomingChatSound', 'outgoingChatSound'];
-
-	batch.processSortedSet('users:joindate', processUserBatch, callback);
-
-	function processUserBatch(ids, next) {
-		console.log('Seckhen Ariel Andrade Cuellar');
-		async.each(ids, updateUserSettings, next);
-	}
-
-	function updateUserSettings(uid, next) {
-		console.log('Seckhen Ariel Andrade Cuellar');
-		db.getObject(`user:${uid}:settings`, (err, settings) => {
-			if (err || !settings) {
-				return next(err);
-			}
-
-			const newSettings = keys.reduce((acc, key) => {
-				if (settings[key] && !settings[key].includes(' | ')) {
-					acc[key] = soundMap[settings[key]] || '';
-				}
-				return acc;
-			}, {});
-
-			if (Object.keys(newSettings).length) {
-				db.setObject(`user:${uid}:settings`, newSettings, next);
-			} else {
-				setImmediate(next);
-			}
-		});
-	}
-}
 
 module.exports = {
 	name: 'Update global and user sound settings',
 	timestamp: Date.UTC(2017, 1, 25),
 	method: function (callback) {
+		const meta = require('../../meta');
+		const batch = require('../../batch');
+
+		const map = {
+			'notification.mp3': 'Default | Deedle-dum',
+			'waterdrop-high.mp3': 'Default | Water drop (high)',
+			'waterdrop-low.mp3': 'Default | Water drop (low)',
+		};
+
 		async.parallel([
-			updateGlobalSoundSettings,
-			updateUserSoundSettings,
+			function (cb) {
+				const keys = ['chat-incoming', 'chat-outgoing', 'notification'];
+
+				db.getObject('settings:sounds', (err, settings) => {
+					if (err || !settings) {
+						return cb(err);
+					}
+
+					keys.forEach((key) => {
+						if (settings[key] && !settings[key].includes(' | ')) {
+							settings[key] = map[settings[key]] || '';
+						}
+					});
+
+					meta.configs.setMultiple(settings, cb);
+				});
+			},
+			function (cb) {
+				const keys = ['notificationSound', 'incomingChatSound', 'outgoingChatSound'];
+
+				batch.processSortedSet('users:joindate', (ids, next) => {
+					async.each(ids, (uid, next) => {
+						db.getObject(`user:${uid}:settings`, (err, settings) => {
+							if (err || !settings) {
+								return next(err);
+							}
+							const newSettings = {};
+							keys.forEach((key) => {
+								if (settings[key] && !settings[key].includes(' | ')) {
+									newSettings[key] = map[settings[key]] || '';
+								}
+							});
+
+							if (Object.keys(newSettings).length) {
+								db.setObject(`user:${uid}:settings`, newSettings, next);
+							} else {
+								setImmediate(next);
+							}
+						});
+					}, next);
+				}, cb);
+			},
 		], callback);
 	},
 };


### PR DESCRIPTION
Reverts CMU-17313Q/nodebb-f24-swifties#30

We recently encountered an issue where multiple pull requests were merged without adhering to the required guidelines. Mainly, we merged without the reviewers confirming first on GitHub. We did this because when we added the reviewers, the merge button was still clickable, so we thought in this assignment it was okay to merge as long as reviewers just took a look and were okay with it, having worked right next to each other, without clicking the button on git. To resolve this, and create pull requests with proper reviewer GitHub acceptance, we had to revert each of the pull requests individually, rolling the codebase back to the starting point before these changes were introduced. This process was necessary to ensure stability and compliance with the project’s guidelines, and we are now taking corrective steps to follow proper procedures going forward to avoid similar setbacks. As a next step, we will revert the reverts from the newest one to the oldest one with the reviewers assigned and confirmed, so that we are essentially doing everything correctly as if from the beginning code.