### PR TITLE
Revert "Revert "replicated project1 changes here too""

### DIFF
--- a/src/upgrades/1.1.1/upload_privileges.js
+++ b/src/upgrades/1.1.1/upload_privileges.js
@@ -1,38 +1,77 @@
 'use strict';
 
-const async = require('async');
 const db = require('../../database');
-
 
 module.exports = {
 	name: 'Giving upload privileges',
 	timestamp: Date.UTC(2016, 6, 12),
-	method: function (callback) {
+	method: async function () {
+		console.log('graissov: Executing method function');
 		const privilegesAPI = require('../../privileges');
 		const meta = require('../../meta');
 
-		db.getSortedSetRange('categories:cid', 0, -1, (err, cids) => {
-			if (err) {
-				return callback(err);
-			}
-
-			async.eachSeries(cids, (cid, next) => {
-				privilegesAPI.categories.list(cid, (err, data) => {
-					if (err) {
-						return next(err);
-					}
-					async.eachSeries(data.groups, (group, next) => {
-						if (group.name === 'guests' && parseInt(meta.config.allowGuestUploads, 10) !== 1) {
-							return next();
-						}
-						if (group.privileges['groups:read']) {
-							privilegesAPI.categories.give(['upload:post:image'], cid, group.name, next);
-						} else {
-							next();
-						}
-					}, next);
-				});
-			}, callback);
-		});
+		const cids = await getCategoryIds();
+		await processCategories(cids, privilegesAPI, meta);
 	},
 };
+
+// Helper function to get category IDs
+function getCategoryIds() {
+	console.log('graissov: Executing getCategoryIds function');
+	return new Promise((resolve, reject) => {
+		db.getSortedSetRange('categories:cid', 0, -1, (err, cids) => {
+			if (err) {
+				return reject(err);
+			}
+			resolve(cids);
+		});
+	});
+}
+
+// Helper function to process each category
+async function processCategories(cids, privilegesAPI, meta) {
+	console.log('graissov: Executing processCategories function');
+	await Promise.all(cids.map(async (cid) => {
+		const data = await getCategoryData(cid, privilegesAPI);
+		await processGroups(data.groups, cid, privilegesAPI, meta);
+	}));
+}
+
+// Helper function to get category data
+function getCategoryData(cid, privilegesAPI) {
+	console.log('graissov: Executing getCategoryData function');
+	return new Promise((resolve, reject) => {
+		privilegesAPI.categories.list(cid, (err, data) => {
+			if (err) {
+				return reject(err);
+			}
+			resolve(data);
+		});
+	});
+}
+
+// Helper function to process groups within a category
+async function processGroups(groups, cid, privilegesAPI, meta) {
+	console.log('graissov: Executing processGroups function');
+	await Promise.all(groups.map(async (group) => {
+		if (group.name === 'guests' && parseInt(meta.config.allowGuestUploads, 10) !== 1) {
+			return; // Skip guests if uploads are not allowed
+		}
+		if (group.privileges['groups:read']) {
+			await giveUploadPrivilege(cid, group.name, privilegesAPI);
+		}
+	}));
+}
+
+// Helper function to give upload privileges
+function giveUploadPrivilege(cid, groupName, privilegesAPI) {
+	console.log('graissov: Executing giveUploadPrivilege function');
+	return new Promise((resolve, reject) => {
+		privilegesAPI.categories.give(['upload:post:image'], cid, groupName, (err) => {
+			if (err) {
+				return reject(err);
+			}
+			resolve();
+		});
+	});
+}


### PR DESCRIPTION
Reverts CMU-17313Q/nodebb-f24-swifties#55

Important Note: This pull request reverts a previously reverted change, restoring the feature to its original state. The purpose is to ensure that the correct reviewers are assigned to each task we implemented. Due to a repository configuration issue, automatic merging occurred before the assigned reviewers had officially approved the code. Although the reviewers completed their reviews on time, GitHub merged the code prematurely.

This "undo revert" pull request restores the changes from the original pull request #31. Please refer to that pull request to view the commit messages, as they are not displayed here. The reviewers from that pull request #31 can be seen here.